### PR TITLE
Chained Wallet

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,4 +3,5 @@ export * from "./translucent/mod.ts";
 export * from "./provider/mod.ts";
 export * from "./types/mod.ts";
 export * from "./utils/mod.ts";
+export * from "./wallets/mod.ts";
 export * from "./plutus/mod.ts";

--- a/src/wallets/chained.ts
+++ b/src/wallets/chained.ts
@@ -36,12 +36,12 @@ export class ChainedWallet implements AbstractWallet {
     const inputs = txCore.body().inputs()
     const outputs = txCore.body().outputs()
     const toConsume: Record<string, boolean> = {}
-    for (let i=0; i<=inputs.len(); i++){
+    for (let i=0; i<inputs.len(); i++){
         const input = inputs.get(i);
         toConsume[input.transaction_id().to_hex() + input.index()] = true
     }
-    this.utxos = this.utxos.filter((utxo)=>toConsume[utxo.txHash+utxo.outputIndex.toString()]!=undefined)
-    for (let i=0; i<=outputs.len(); i++){
+    this.utxos = this.utxos.filter((utxo)=>toConsume[utxo.txHash+utxo.outputIndex.toString()]==true)
+    for (let i=0; i<outputs.len(); i++){
         const output = C.TransactionUnspentOutput.new(C.TransactionInput.new(hash, C.BigNum.from_str(i.toString())), outputs.get(i))
         const utxo = coreToUtxo(output);
         if (predicate(utxo)){

--- a/src/wallets/chained.ts
+++ b/src/wallets/chained.ts
@@ -1,0 +1,92 @@
+import {
+  UTxO,
+  C,
+  Delegation,
+  Payload,
+  TxHash,
+  SignedMessage,
+  Address,
+  RewardAddress,
+  Transaction,
+  Translucent,
+  utxoToCore,
+  fromHex,
+  coreToUtxo,
+} from '../mod'
+import { AbstractWallet } from './abstract'
+
+export class ChainedWallet implements AbstractWallet {
+  translucent: Translucent
+  wallet: AbstractWallet
+  utxos: UTxO[] = []
+
+  constructor(translucent: Translucent, wallet: AbstractWallet) {
+    this.translucent = translucent
+    this.wallet = wallet
+    wallet.getUtxos().then((utxos) => (this.utxos = utxos))
+  }
+
+  async refreshUtxos() {
+    this.utxos = await this.wallet.getUtxos()
+  }
+
+  async chain(tx: Transaction, predicate: (utxo: UTxO)=>boolean){
+    const txCore = C.Transaction.from_bytes(fromHex(tx))
+    const hash = C.hash_transaction(txCore.body())
+    const inputs = txCore.body().inputs()
+    const outputs = txCore.body().outputs()
+    const toConsume: Record<string, boolean> = {}
+    for (let i=0; i<=inputs.len(); i++){
+        const input = inputs.get(i);
+        toConsume[input.transaction_id().to_hex() + input.index()] = true
+    }
+    this.utxos = this.utxos.filter((utxo)=>toConsume[utxo.txHash+utxo.outputIndex.toString()]!=undefined)
+    for (let i=0; i<=outputs.len(); i++){
+        const output = C.TransactionUnspentOutput.new(C.TransactionInput.new(hash, C.BigNum.from_str(i.toString())), outputs.get(i))
+        const utxo = coreToUtxo(output);
+        if (predicate(utxo)){
+            this.utxos.push(utxo);
+        };
+    };
+  }
+
+  address(): Promise<Address> {
+    return this.wallet.address()
+  }
+
+  rewardAddress(): Promise<RewardAddress | null> {
+    return this.wallet.rewardAddress()
+  }
+
+  getUtxos(): Promise<UTxO[]> {
+    return Promise.resolve(this.utxos)
+  }
+
+  getUtxosCore(): Promise<C.TransactionUnspentOutputs> {
+    const outputs = C.TransactionUnspentOutputs.new()
+    const utxos = this.utxos.map(utxoToCore)
+    for (const utxo of utxos){
+        outputs.add(utxo)
+    }
+    return Promise.resolve(outputs)
+  }
+
+  getDelegation(): Promise<Delegation> {
+    return this.wallet.getDelegation()
+  }
+
+  signTx(tx: C.Transaction): Promise<C.TransactionWitnessSet> {
+    return this.wallet.signTx(tx)
+  }
+
+  signMessage(
+    address: Address | RewardAddress,
+    payload: Payload,
+  ): Promise<SignedMessage> {
+    return this.wallet.signMessage(address, payload)
+  }
+
+  submitTx(signedTx: Transaction): Promise<TxHash> {
+    return this.wallet.submitTx(signedTx)
+  }
+}

--- a/src/wallets/mod.ts
+++ b/src/wallets/mod.ts
@@ -1,0 +1,6 @@
+export * from "./abstract"
+export * from "./chained"
+export * from "./private_key"
+export * from "./public_wallet"
+export * from "./seed"
+export * from "./wallet_connector"


### PR DESCRIPTION
A version of wallet with more manual controls over utxo availability and an easy way to chain. If you want to use chaining for specific reasons you can wrap whatever wallet is enabled in translucent, do some chaining, then unwrap back, or you can have full manual control over when utxos are queried. 